### PR TITLE
put mialib files in the correct location on macos and linux

### DIFF
--- a/src/main/java/xyz/amymialee/mialib/mixin/client/ResourcePackManagerMixin.java
+++ b/src/main/java/xyz/amymialee/mialib/mixin/client/ResourcePackManagerMixin.java
@@ -15,8 +15,8 @@ import xyz.amymialee.mialib.util.MDir;
 public class ResourcePackManagerMixin {
     @WrapOperation(method = "<init>", at = @At(value = "INVOKE", target = "Lcom/google/common/collect/ImmutableSet;copyOf([Ljava/lang/Object;)Lcom/google/common/collect/ImmutableSet;"), remap = false)
     private ImmutableSet<ResourcePackProvider> mialib$moreDirs(Object @NotNull [] array, @NotNull Operation<ImmutableSet<ResourcePackProvider>> operation) {
-        var universalDir = MDir.getMialibPath("resourcepacks/universal");
-        var versionDir = MDir.getMialibPath("resourcepacks/pack_format_" + SharedConstants.getGameVersion().packVersion(ResourceType.CLIENT_RESOURCES));
+        var universalDir = MDir.getMialibPath("resourcepacks", "universal");
+        var versionDir = MDir.getMialibPath("resourcepacks", "pack_format_" + SharedConstants.getGameVersion().packVersion(ResourceType.CLIENT_RESOURCES));
         var universalProvider = new FileResourcePackProvider(universalDir, ResourceType.CLIENT_RESOURCES, ResourcePackSource.NONE, MinecraftClient.getInstance().getSymlinkFinder());
         var versionProvider = new FileResourcePackProvider(versionDir, ResourceType.CLIENT_RESOURCES, ResourcePackSource.NONE, MinecraftClient.getInstance().getSymlinkFinder());
         var combined = new ResourcePackProvider[array.length + 2];

--- a/src/main/java/xyz/amymialee/mialib/mixin/server/ResourcePackManagerMixin.java
+++ b/src/main/java/xyz/amymialee/mialib/mixin/server/ResourcePackManagerMixin.java
@@ -15,8 +15,8 @@ import xyz.amymialee.mialib.util.MDir;
 public class ResourcePackManagerMixin {
     @WrapOperation(method = "<init>", at = @At(value = "INVOKE", target = "Lcom/google/common/collect/ImmutableSet;copyOf([Ljava/lang/Object;)Lcom/google/common/collect/ImmutableSet;"), remap = false)
     private ImmutableSet<ResourcePackProvider> mialib$moreDirs(Object @NotNull [] array, @NotNull Operation<ImmutableSet<ResourcePackProvider>> operation) {
-        var universalDir = MDir.getMialibPath("datapacks/universal");
-        var versionDir = MDir.getMialibPath("datapacks/pack_format_" + SharedConstants.getGameVersion().packVersion(ResourceType.SERVER_DATA));
+        var universalDir = MDir.getMialibPath("datapacks", "universal");
+        var versionDir = MDir.getMialibPath("datapacks", "pack_format_" + SharedConstants.getGameVersion().packVersion(ResourceType.SERVER_DATA));
         var universalProvider = new FileResourcePackProvider(universalDir, ResourceType.SERVER_DATA, ResourcePackSource.NONE, new SymlinkFinder(path -> true));
         var versionProvider = new FileResourcePackProvider(versionDir, ResourceType.SERVER_DATA, ResourcePackSource.NONE, new SymlinkFinder(path -> true));
         var combined = new ResourcePackProvider[array.length + 2];

--- a/src/main/java/xyz/amymialee/mialib/util/MDir.java
+++ b/src/main/java/xyz/amymialee/mialib/util/MDir.java
@@ -1,22 +1,70 @@
 package xyz.amymialee.mialib.util;
 
+import net.minecraft.util.Util;
 import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.Nullable;
+import xyz.amymialee.mialib.Mialib;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 /**
  * Get a file or path in the mialib appdata directory.
  */
 public interface MDir {
+    static final @Nullable String MIALIB_DIR_OVERRIDE = System.getProperty("mialib.mdir");
+
+    static @NotNull Path getMialibPath(Path relative) {
+        return MDirImpl.INSTANCE.path.resolve(relative);
+    }
+
     static @NotNull Path getMialibPath(String fileName) {
-        return getMialibFile(fileName).toPath();
+        return MDirImpl.INSTANCE.path.resolve(fileName);
+    }
+
+    static @NotNull Path getMialibPath(String first, String... more) {
+        return MDirImpl.INSTANCE.path.resolve(Path.of(first, more));
     }
 
     static @NotNull File getMialibFile(String fileName) {
-        if (System.getProperty("os.name").toUpperCase().contains("WIN")) {
-            return new File(System.getenv("AppData"), ".mialib/" + fileName);
+        return getMialibPath(fileName).toFile();
+    }
+
+    static class MDirImpl {
+        private static final MDirImpl INSTANCE = new MDirImpl();
+        private final Path path;
+
+        public MDirImpl() {
+            if (MIALIB_DIR_OVERRIDE != null) {
+                Mialib.LOGGER.info("mialib directory overridden, setting to {}", MIALIB_DIR_OVERRIDE);
+                this.path = Paths.get(MIALIB_DIR_OVERRIDE);
+                return;
+            }
+            var userHome = System.getProperty("user.home");
+            var fallback = Path.of(userHome, ".mialib");
+            this.path = switch (Util.getOperatingSystem()) {
+                case WINDOWS -> {
+                    String appData = System.getenv("AppData");
+                    if (appData == null) {
+                        Mialib.LOGGER.warn("No value for AppData env var even though we're on windows, falling back to {}", fallback);
+                        yield fallback;
+                    }
+                    yield Path.of(appData, ".mialib");
+                }
+                case OSX -> Path.of(userHome, "Library", "Application Support", "mialib");
+                case LINUX -> {
+                    String xdgData = System.getenv("XDG_DATA_HOME");
+                    var localShare = Path.of(userHome, ".local", "share", "mialib");
+                    if (xdgData == null) {
+                        Mialib.LOGGER.warn("No value for XDG_DATA_HOME, falling back to {}", localShare);
+                        yield localShare;
+                    }
+                    yield Path.of(xdgData, "mialib");
+                }
+                case UNKNOWN, SOLARIS -> fallback;
+            };
+            Mialib.LOGGER.info("Set mialib directory to {}", this.path);
         }
-        return new File(System.getProperty("user.home") + "/.local/share", "mialib/" + fileName);
     }
 }


### PR DESCRIPTION
macos uses `~/Library/Application Support/mialib`, and linux now uses `$XDG_DATA_HOME/mialib`, falling back to `~/.local/share/mialib` if that variable is not defined.

`~/.mialib` is used on unknown and solaris OSes, and windows if appdata is somehow not defined.